### PR TITLE
Queue Creation

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -7,5 +7,6 @@ services:
     environment:
       ENV_NAME: dev
       SQS_URL: "http://localhost:9324/queue/example"
-      LAMBDA_FUNCTION_NAME: "index.handler"
+      CREATE_QUEUE: "true"
+      LAMBDA_HANDLER: "index.handler"
       LAMBDA_ENDPOINT: "http://localhost:9001"

--- a/src/aws/sqs.ts
+++ b/src/aws/sqs.ts
@@ -4,14 +4,40 @@ import * as AWS from "aws-sdk"
 
 export class SQS {
     readonly sqs: AWS.SQS
+    readonly sqsEndpoint: string
     readonly sqsUrl: string
+    readonly queueName: string
 
-    constructor(endpoint: string, sqsUrl:string) {
+    constructor(sqsUrl: string) {
+        const splitURL = sqsUrl.split("/");
+        const sqsEndpoint = splitURL[0] + "//" + splitURL[2];
+        const queueName = splitURL[splitURL.length - 1];
+
         this.sqs = new AWS.SQS({
             apiVersion: "2015-03-31",
-            endpoint,
-        })
-        this.sqsUrl = sqsUrl
+            endpoint: sqsEndpoint
+        });
+        this.sqsEndpoint = sqsEndpoint;
+        this.sqsUrl = sqsUrl;
+        this.queueName = queueName;
+    }
+
+    async createQueue(): Promise<any> {
+        try {
+            const params = {
+                QueueName: this.queueName,
+            };
+            await this.sqs.createQueue(params).promise();
+            console.log("DONE CREATING QUEUE!");
+        } catch(err) {
+            if (err.toString().indexOf("NetworkingError: connect ECONNREFUSED") >= 0) {
+                console.log("WAITING FOR SQS...");
+                await new Promise(resolve => setTimeout(resolve, 1000))
+                await this.createQueue();
+            } else {
+                console.log(err.toString());
+            }
+        }
     }
 
     async receiveMessage(): Promise<AWS.SQS.MessageList | undefined> {
@@ -22,7 +48,7 @@ export class SQS {
             VisibilityTimeout: 10,
             WaitTimeSeconds: 5, // how long to wait before returning
         }
-        const { Messages } = await this.sqs.receiveMessage(params).promise()
+        const { Messages } = await (this.sqs as AWS.SQS).receiveMessage(params).promise()
         return Messages
     }
 
@@ -31,7 +57,7 @@ export class SQS {
             return
         }
 
-        await this.sqs.deleteMessage({
+        await (this.sqs as AWS.SQS).deleteMessage({
             QueueUrl: this.sqsUrl,
             ReceiptHandle: receiptHandle,
         }).promise()

--- a/src/helper.ts
+++ b/src/helper.ts
@@ -1,25 +1,27 @@
 export function getConfig() {
     const sqsUrl = process.env.SQS_URL
-    const handler = process.env.LAMBDA_HANDLER
-    const endpoint = process.env.LAMBDA_ENDPOINT
+    const createQueue = Boolean(process.env.CREATE_QUEUE)
+    const lambdaHandler = process.env.LAMBDA_HANDLER
+    const lambdaEndpoint = process.env.LAMBDA_ENDPOINT
 
     console.debug("sqslUrl", sqsUrl);
-    console.debug("handler", handler);
-    console.debug("endpoint", endpoint);
+    console.debug("lambdaHandler", lambdaHandler);
+    console.debug("lambdaEndpoint", lambdaEndpoint);
+    console.debug("createQueue", createQueue)
 
     if (!sqsUrl) {
         throw new Error("Missing SQS_URL");
     }
-    if (!handler) {
+    if (!lambdaHandler) {
         throw new Error("Missing LAMBDA_HANDLER");
     }
-    if (!endpoint) {
+    if (!lambdaEndpoint) {
         throw new Error("Missing LAMBDA_ENDPOINT");
     }
-
     return {
         sqsUrl,
-        handler,
-        endpoint,
+        createQueue,
+        lambdaHandler,
+        lambdaEndpoint,
     }
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -13,7 +13,6 @@ async function poll(
     }
 
     await Promise.all(Messages.map(async message => {
-
         try {
             await lambda.run(message.Body)
         } catch (err) {
@@ -23,17 +22,23 @@ async function poll(
 
         await sqs.deleteMessage(message.ReceiptHandle)
     }))
-}  
+}
 
 async function infinityRun() {
     const {
         sqsUrl,
-        handler,
-        endpoint,
+        createQueue,
+        lambdaHandler,
+        lambdaEndpoint,
     } = getConfig()
 
-    const sqs = new SQS(endpoint, sqsUrl)
-    const lambda = new Lambda(endpoint, handler)
+    const sqs = new SQS(sqsUrl);
+
+    if (createQueue) {
+        await sqs.createQueue();
+    }
+
+    const lambda = new Lambda(lambdaEndpoint, lambdaHandler)
 
     // TODO: register handler for interruptions
     while (true) {


### PR DESCRIPTION
- Added option to create an SQS queue if it doesn't exist. The variable is called CREATE_QUEUE and is taken from the environment variables.
- Changed the constructor to pull the SQS endpoint and queue name from the SQS URL.
- Added the createQueue() function. It will create the queue specified in the SQS URL if the environment variable CREATE_QUEUE is set to "true". As the SQS may still be starting up, it recursively checks until the SQS instance becomes available.